### PR TITLE
Build profile for "Proj"

### DIFF
--- a/mkit.profiles.sh
+++ b/mkit.profiles.sh
@@ -447,4 +447,11 @@ profile_bzip2()
  add_run_dep bzip2
 }
 
+profile_proj()
+{
+ add_run_dep sqlite3
+ add_run_dep libtiff
+ add_run_dep proj
+}
+
 ### EOF ###

--- a/modules/libtiff/build.sh
+++ b/modules/libtiff/build.sh
@@ -1,0 +1,7 @@
+build_libtiff()
+{
+ [ -d "${prefix}/lib/pkgconfig" ] && export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig";
+
+ build_gnuconf libtiff $srcdir_libtiff 
+ return $?
+}

--- a/modules/proj/build.sh
+++ b/modules/proj/build.sh
@@ -1,0 +1,7 @@
+build_proj()
+{
+ [ -d "${prefix}/lib/pkgconfig" ] && export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig";
+
+ build_gnuconf proj $srcdir_proj 
+ return $?
+}


### PR DESCRIPTION
Build profile for "proj" cartography software, does not build with gcc 4.8.2 but works with gcc 9.2.0.